### PR TITLE
Fix: parse javascript parameters when parameter is object

### DIFF
--- a/cm_parser/javascript.vim
+++ b/cm_parser/javascript.vim
@@ -15,7 +15,7 @@ function! s:parser0(menu) "{{{
         let param = substitute(param, '\m\<fn([^)]*)', '', 'g')
     endwhile
     while param =~# '\w\+\s*:\s*{[^{}]*}'
-        let param = substitute(param, '\m\(\w\+)\s*:{[^{}]*}', '\1', 'g')
+        let param = substitute(param, '\m\(\w\+\):\s{[^{}]*}', '\1', 'g')
     endwhile
     let param = substitute(param, '\m?\?:\s*[^,)]*', '', 'g')
     return [param]

--- a/vader/javascript.vader
+++ b/vader/javascript.vader
@@ -34,6 +34,11 @@ Execute (fn(test: {elt: string, i: number, array: Array}, context?: ?) -> bool):
   let completed_item = {'menu': 'fn(test: fn(elt: ?, i: number, array: Array) -> bool, context?: ?) -> bool'}
   let result = cm_parser#javascript#parameters(completed_item)
   AssertEqual ['(test, context)'], result
+
+Execute (fn(options: {compressible: bool, extensions: [?], register: ?, source: string, type: string})):
+  let completed_item = {'menu': 'fn(options: {compressible: bool, extensions: [?], register: ?, source: string, type: string})'}
+  let result = cm_parser#javascript#parameters(completed_item)
+  AssertEqual ['(options)'], result
 "}}}
 
 "{{{ deoplete


### PR DESCRIPTION
The previous regular expression parser failed to parse parameters that
were objects with properties. The regular expression was simply written
wrong. Tested with example code in #13 and it seems to work.

https://github.com/tenfyzhong/CompleteParameter.vim/issues/13.

# PR Prelude

Thank you for working on ComplateParameter!

**Please complete these steps and check these boxes (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]
