### PR TITLE
Make it compatible with coc.nvim in C/C++ or Python editing mode.

### DIFF
--- a/cm_parser/c.vim
+++ b/cm_parser/c.vim
@@ -18,7 +18,7 @@ endfunction
 
 
 function! s:parse(abbr) "{{{
-    let param = substitute(a:abbr, '\m\%(\w\+\s*\)\?\w\+\((.*)\)', '\1', '') " get parameters
+    let param = substitute(a:abbr, '\m\%(\w\+\s*\)\?\w\+\((.*)\).*', '\1', '') " get parameters
     let param = substitute(param, '\m\([(,]\)\s*\%(\w\+\s\+\)*\s*\(\w\+\s*\)\s*\(\**\)\(\s*[,)]\)', '\1\2 \3\2\4', 'g')
     let param = substitute(param, '\m\s*\%(\w\+\s\+\)*\s*\**\s*\(\%(\w\+\)\s*[,)]\)', '\1', 'g')
     let param = substitute(param, '\s\+', '', 'g')

--- a/cm_parser/python.vim
+++ b/cm_parser/python.vim
@@ -16,6 +16,12 @@ function! s:signature(info) "{{{
   let match = 0
   let l:finish = 0
 
+  if info_lines[0] !~# '('
+    if info_lines[0] !~# '```' || len(info_lines) == 1 || info_lines[1] !~# '('
+      return func
+    endif
+  endif
+
   " there are maybe some () in the parameters
   " if the count of `(` equal to `)` 
   " then the parameters has finished
@@ -92,7 +98,10 @@ function! cm_parser#python#parameters(completed_item) "{{{
   let word = get(a:completed_item, 'word', '')
   let abbr = get(a:completed_item, 'abbr', '')
   let kind = get(a:completed_item, 'kind', '')
-  if (menu =~# '\m^\%(function:\|def \)' || word =~# '\m^\w\+($' || menu =~? '\[jedi\]\s*') || !empty(info)
+  if (menu =~# '\m^\%(function:\|def \)' || word =~# '\m^\w\+($' || menu =~? '\[jedi\]\s*') && !empty(info)
+    return s:parser0(info)
+  " From language server.
+  elseif  menu =~? '\[LS\]' && !empty(info)
     return s:parser0(info)
   elseif word ==# '(' && empty(menu) && info ==# ' ' && empty(kind) && !empty(abbr)
     " ycm omni called

--- a/cm_parser/python.vim
+++ b/cm_parser/python.vim
@@ -16,10 +16,6 @@ function! s:signature(info) "{{{
   let match = 0
   let l:finish = 0
 
-  if info_lines[0] !~# '('
-    return func
-  endif
-
   " there are maybe some () in the parameters
   " if the count of `(` equal to `)` 
   " then the parameters has finished
@@ -96,7 +92,7 @@ function! cm_parser#python#parameters(completed_item) "{{{
   let word = get(a:completed_item, 'word', '')
   let abbr = get(a:completed_item, 'abbr', '')
   let kind = get(a:completed_item, 'kind', '')
-  if (menu =~# '\m^\%(function:\|def \)' || word =~# '\m^\w\+($' || menu =~? '\[jedi\]\s*') && !empty(info)
+  if (menu =~# '\m^\%(function:\|def \)' || word =~# '\m^\w\+($' || menu =~? '\[jedi\]\s*') || !empty(info)
     return s:parser0(info)
   elseif word ==# '(' && empty(menu) && info ==# ' ' && empty(kind) && !empty(abbr)
     " ycm omni called

--- a/vader/c.vader
+++ b/vader/c.vader
@@ -127,4 +127,9 @@ Execute (fun( const struct tm *restrict, char *restrict  )):
   let completed_item = {'kind': 'f', 'menu': 'void fun( const struct tm *restrict, char *restrict  )', 'word': 'fun', 'abbr': 'fun'}
   let result = cm_parser#c#parameters(completed_item)
   AssertEqual ['(restrict, restrict)'], result
+
+Execute (coc.nvim + ccls):
+  let completed_item = {'word': 'fun', 'menu': '[LS]', 'user_data': '{"cid":1578967270,"source":"languageserver.ccls","index":0}', 'info': '', 'kind': 'f', 'abbr': 'fun(int x, int y) -> int~'}
+  let result = cm_parser#c#parameters(completed_item)
+  AssertEqual ['(x, y)'], result
 "}}}

--- a/vader/python.vader
+++ b/vader/python.vader
@@ -259,6 +259,10 @@ Execute (jedi):
   let result = cm_parser#python#parameters(completed_item)
   AssertEqual ['(arg1, arg2)'], result
 
+Execute (coc.nvim + coc-pyhon[MPLS]):
+  let completed_item = {'word': 'fun', 'menu': '[LS]', 'user_data': '{"cid":1578967439,"source":"python","index":8}', 'info': '```\nfun(x, y)\n```', 'kind': 'v', 'abbr': 'fun'}
+  let result = cm_parser#python#parameters(completed_item)
+  AssertEqual ['(x, y)'], result
 
 " echos
 Execute (echos, foo):


### PR DESCRIPTION
The complete items produced by coc.nvim have some minor differences, with are not compatible with existing parsers. 
In C/C++ mode, the complete item which produced by coc.nvim + ccls has this form:
```
fun(int x, int y) -> int~
```
In python mode, the complete item which produced by coc.nvim + coc-python[MPLS] has this form:
````
```
fun(x, y)
```
````