### PR TITLE
Support coc.nvim with C++

### DIFF
--- a/cm_parser/cpp.vim
+++ b/cm_parser/cpp.vim
@@ -64,7 +64,8 @@ function! cm_parser#cpp#parameters(completed_item) "{{{
     let word = get(a:completed_item, 'word', '')
     let info = get(a:completed_item, 'info', '')
     let l:menu = get(a:completed_item, 'menu', '')
-    if kind ==# 'f'
+    let l:abbr = get(a:completed_item, 'abbr', '')
+    if kind ==# 'f' && !empty(info)
       return <SID>parse_function(word, info)
     elseif kind ==# 'c'
       return <SID>parse_class(word, info)
@@ -74,6 +75,12 @@ function! cm_parser#cpp#parameters(completed_item) "{{{
       return <SID>parse_class(word, info)
     elseif kind ==# 'm'
       return <SID>parse_macro(word, info)
+    elseif kind ==# 'f'
+        return <SID>parse_function(word, l:abbr)
+    elseif kind ==# 'C'
+        return <SID>parse_class(word, l:abbr)
+    elseif kind ==# 'v'
+        return <SID>parse_macro(word, l:abbr)
     else
       return []
     endif

--- a/vader/c.vader
+++ b/vader/c.vader
@@ -132,4 +132,9 @@ Execute (coc.nvim + ccls):
   let completed_item = {'word': 'fun', 'menu': '[LS]', 'user_data': '{"cid":1578967270,"source":"languageserver.ccls","index":0}', 'info': '', 'kind': 'f', 'abbr': 'fun(int x, int y) -> int~'}
   let result = cm_parser#c#parameters(completed_item)
   AssertEqual ['(x, y)'], result
+
+Execute (coc.nvim + clangd):
+  let completed_item = {'word': 'fun', 'menu': 'void [LS]', 'user_data': '{"cid":1587074277,"source":"clangd","index":0}', 'info': '', 'kind': 'f', 'abbr': 'fun(int x, int y)~'}
+  let result = cm_parser#c#parameters(completed_item)
+  AssertEqual ['(x, y)'], result
 "}}}

--- a/vader/cpp.vader
+++ b/vader/cpp.vader
@@ -116,3 +116,25 @@ Execute (std:: error_code, kind: p):
   let result = cm_parser#cpp#parameters(completed_item)
   AssertEqual [], result
 "}}}
+
+"{{{coc.nvim
+Execute (ccls, kind: f):
+  let completed_item = {'word': 'fun', 'menu': '[LS]', 'user_data': '{"cid":1578967270,"source":"languageserver.ccls","index":0}', 'info': '', 'kind': 'f', 'abbr': 'fun(int x, int y) -> int~'}
+  let result = cm_parser#cpp#parameters(completed_item)
+  AssertEqual ['(x, y)'], result
+
+Execute (clangd, kind: f):
+  let completed_item = {'word': 'fun', 'menu': 'void [LS]', 'user_data': '{"cid":1587074277,"source":"clangd","index":0}', 'info': '', 'kind': 'f', 'abbr': 'fun(int x, int y)~'}
+  let result = cm_parser#cpp#parameters(completed_item)
+  AssertEqual ['(x, y)'], result
+
+Execute (vector<typename _Tp, typename _Alloc>, kind: C):
+  let completed_item = {'word': 'vector', 'menu': ' <vector> [LS]', 'user_data': '{"cid":1587079915,"source":"clangd","index":0}', 'info': '....', 'kind': 'C', 'abbr': 'vector<typename _Tp, typename _Alloc>~'}
+  let result = cm_parser#cpp#parameters(completed_item)
+  AssertEqual ['<_Tp, _Alloc>'], result
+
+Execute (CMP, kind: v):
+  let completed_item = {'word': 'CMP', 'menu': '[LS]', 'user_data': '{"cid":1587080756,"source":"clangd","index":0}', 'info': '', 'kind': 'v', 'abbr': 'CMP(a, b)~'}
+  let result = cm_parser#cpp#parameters(completed_item)
+  AssertEqual ['(a, b)'], result
+"}}}


### PR DESCRIPTION
I'm using coc.nvim with coc-clangd. The previous commit 6f69d75 only enables C, so this PR will make it work with C++ (functions, classes, macros). However I'm not using ccls so it's just tested with coc-clangd.
For completeness I included another coc-clangd test for C.

Overloads are not working yet.